### PR TITLE
Fix for pure virtual function error

### DIFF
--- a/test/elliptic-sipdg-discretization.hh
+++ b/test/elliptic-sipdg-discretization.hh
@@ -14,7 +14,7 @@
 
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
-#include <dune/stuff/grid/entity.hh>
+#include <dune/stuff/grid/information.hh>
 #include <dune/stuff/la/container.hh>
 #include <dune/stuff/la/solver.hh>
 #include <dune/stuff/functions/interfaces.hh>
@@ -299,12 +299,9 @@ public:
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    assert(grid_view.template begin< 0 >() != grid_view.template end< 0 >());
-    const auto& entity = *(grid_view.template begin< 0 >());
-    //calculate longest straight line within the entity (i.e. between two corners).
-    return Dune::Stuff::Grid::entity_diameter(entity);
+    Dune::Stuff::Grid::Dimensions< GridViewType > dimensions(grid_view);
+    return dimensions.entity_width.max();
   } // ... current_grid_width()
 
   virtual double compute_on_current_refinement() override final

--- a/test/elliptic-sipdg-discretization.hh
+++ b/test/elliptic-sipdg-discretization.hh
@@ -299,26 +299,25 @@ public:
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    typedef typename GridViewType::template Codim< 0 >::Iterator EntityIteratorType;
+    //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    EntityIteratorType entity_it_end = grid_view.template end< 0 >();
+    auto entity_it = grid_view.template begin< 0 >();
+    assert(entity_it != grid_view.template end< 0 >());
+    const auto& entity = *entity_it;
+    //calculate longest straight line within the entity (i.e. between two corners).
     double curr_grid_width = 0.0;
     double norm = 0.0;
-    int corners = 0;
-    for (EntityIteratorType entity_it = grid_view.template begin< 0 >(); entity_it != entity_it_end; ++entity_it) {
-      const auto& entity = *entity_it;
-      corners = entity.geometry().corners();
-      for (int corner1 = 0; corner1 < corners; ++corner1) {
-        for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
-          auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
-          norm = corner_diff.two_norm();
-          if (Dune::FloatCmp::gt(norm, curr_grid_width))
-            curr_grid_width = norm;
-        }
+    const int corners = entity.geometry().corners();
+    for (int corner1 = 0; corner1 < corners; ++corner1) {
+      for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
+        auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
+        norm = corner_diff.two_norm();
+        if (Dune::FloatCmp::gt(norm, curr_grid_width))
+          curr_grid_width = norm;
       }
     }
     return curr_grid_width;
-  }
+  } // ... current_grid_width()
 
   virtual double compute_on_current_refinement() override final
   {

--- a/test/elliptic-sipdg-discretization.hh
+++ b/test/elliptic-sipdg-discretization.hh
@@ -12,8 +12,6 @@
 
 #include <dune/common/timer.hh>
 
-#include <dune/fem/misc/gridwidth.hh>
-
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
 #include <dune/stuff/la/container.hh>
@@ -297,10 +295,29 @@ public:
     return test_.level_grid_part(current_level_).indexSet().size(0);
   }
 
+  //! todo: use grid information from dune-stuff once the diameter calculation is implemented
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    return Dune::Fem::GridWidth::calcGridWidth(test_.level_grid_part(current_level_));
+    typedef typename GridViewType::template Codim< 0 >::Iterator EntityIteratorType;
+    const GridViewType grid_view = test_.level_grid_view(current_level_);
+    EntityIteratorType entity_it_end = grid_view.template end< 0 >();
+    double curr_grid_width = 0.0;
+    double norm = 0.0;
+    int corners = 0;
+    for (EntityIteratorType entity_it = grid_view.template begin< 0 >(); entity_it != entity_it_end; ++entity_it) {
+      const auto& entity = *entity_it;
+      corners = entity.geometry().corners();
+      for (int corner1 = 0; corner1 < corners; ++corner1) {
+        for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
+          auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
+          norm = corner_diff.two_norm();
+          if (Dune::FloatCmp::gt(norm, curr_grid_width))
+            curr_grid_width = norm;
+        }
+      }
+    }
+    return curr_grid_width;
   }
 
   virtual double compute_on_current_refinement() override final

--- a/test/elliptic-sipdg-discretization.hh
+++ b/test/elliptic-sipdg-discretization.hh
@@ -14,6 +14,7 @@
 
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
+#include <dune/stuff/grid/entity.hh>
 #include <dune/stuff/la/container.hh>
 #include <dune/stuff/la/solver.hh>
 #include <dune/stuff/functions/interfaces.hh>
@@ -295,28 +296,15 @@ public:
     return test_.level_grid_part(current_level_).indexSet().size(0);
   }
 
-  //! todo: use grid information from dune-stuff once the diameter calculation is implemented
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
     //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    auto entity_it = grid_view.template begin< 0 >();
-    assert(entity_it != grid_view.template end< 0 >());
-    const auto& entity = *entity_it;
+    assert(grid_view.template begin< 0 >() != grid_view.template end< 0 >());
+    const auto& entity = *(grid_view.template begin< 0 >());
     //calculate longest straight line within the entity (i.e. between two corners).
-    double curr_grid_width = 0.0;
-    double norm = 0.0;
-    const int corners = entity.geometry().corners();
-    for (int corner1 = 0; corner1 < corners; ++corner1) {
-      for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
-        auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
-        norm = corner_diff.two_norm();
-        if (Dune::FloatCmp::gt(norm, curr_grid_width))
-          curr_grid_width = norm;
-      }
-    }
-    return curr_grid_width;
+    return Dune::Stuff::Grid::entity_diameter(entity);
   } // ... current_grid_width()
 
   virtual double compute_on_current_refinement() override final

--- a/test/elliptic-sipdg-discretization.hh
+++ b/test/elliptic-sipdg-discretization.hh
@@ -12,6 +12,8 @@
 
 #include <dune/common/timer.hh>
 
+#include <dune/fem/misc/gridwidth.hh>
+
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
 #include <dune/stuff/la/container.hh>
@@ -293,6 +295,12 @@ public:
   {
     assert(current_level_ < test_.num_levels());
     return test_.level_grid_part(current_level_).indexSet().size(0);
+  }
+
+  virtual double current_grid_width() const override
+  {
+    assert(current_level_ < test_.num_levels());
+    return Dune::Fem::GridWidth::calcGridWidth(test_.level_grid_part(current_level_));
   }
 
   virtual double compute_on_current_refinement() override final

--- a/test/elliptic-swipdg-discretization.hh
+++ b/test/elliptic-swipdg-discretization.hh
@@ -319,26 +319,25 @@ public:
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    typedef typename GridViewType::template Codim< 0 >::Iterator EntityIteratorType;
+    //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    EntityIteratorType entity_it_end = grid_view.template end< 0 >();
+    auto entity_it = grid_view.template begin< 0 >();
+    assert(entity_it != grid_view.template end< 0 >());
+    const auto& entity = *entity_it;
+    //calculate longest straight line within the entity (i.e. between two corners).
     double curr_grid_width = 0.0;
     double norm = 0.0;
-    int corners = 0;
-    for (EntityIteratorType entity_it = grid_view.template begin< 0 >(); entity_it != entity_it_end; ++entity_it) {
-      const auto& entity = *entity_it;
-      corners = entity.geometry().corners();
-      for (int corner1 = 0; corner1 < corners; ++corner1) {
-        for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
-          auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
-          norm = corner_diff.two_norm();
-          if (Dune::FloatCmp::gt(norm, curr_grid_width))
-            curr_grid_width = norm;
-        }
+    const int corners = entity.geometry().corners();
+    for (int corner1 = 0; corner1 < corners; ++corner1) {
+      for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
+        auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
+        norm = corner_diff.two_norm();
+        if (Dune::FloatCmp::gt(norm, curr_grid_width))
+          curr_grid_width = norm;
       }
     }
     return curr_grid_width;
-  }
+  } // ... current_grid_width()
 
 
   virtual double compute_on_current_refinement() override

--- a/test/elliptic-swipdg-discretization.hh
+++ b/test/elliptic-swipdg-discretization.hh
@@ -17,13 +17,13 @@
 #include <dune/geometry/quadraturerules.hh>
 
 #include <dune/stuff/common/memory.hh>
+#include <dune/stuff/common/convergence-study.hh>
+#include <dune/stuff/grid/information.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
-#include <dune/stuff/grid/entity.hh>
 #include <dune/stuff/la/container.hh>
 #include <dune/stuff/la/solver.hh>
 #include <dune/stuff/functions/interfaces.hh>
 #include <dune/stuff/functions/ESV2007.hh>
-#include <dune/stuff/common/convergence-study.hh>
 #include <dune/stuff/functions/combined.hh>
 
 #include <dune/gdt/playground/spaces/discontinuouslagrange/fem.hh>
@@ -319,12 +319,9 @@ public:
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    assert(grid_view.template begin< 0 >() != grid_view.template end< 0 >());
-    const auto& entity = *(grid_view.template begin< 0 >());
-    //calculate longest straight line within the entity (i.e. between two corners).
-    return Dune::Stuff::Grid::entity_diameter(entity);
+    Dune::Stuff::Grid::Dimensions< GridViewType > dimensions(grid_view);
+    return dimensions.entity_width.max();
   } // ... current_grid_width()
 
   virtual double compute_on_current_refinement() override

--- a/test/elliptic-swipdg-discretization.hh
+++ b/test/elliptic-swipdg-discretization.hh
@@ -14,6 +14,8 @@
 
 #include <dune/common/timer.hh>
 
+#include <dune/fem/misc/gridwidth.hh>
+
 #include <dune/stuff/common/disable_warnings.hh>
 #include <dune/geometry/quadraturerules.hh>
 #include <dune/stuff/common/reenable_warnings.hh>
@@ -315,6 +317,12 @@ public:
   {
     assert(current_level_ < test_.num_levels());
     return test_.level_grid_view(current_level_).indexSet().size(0);
+  }
+
+  virtual double current_grid_width() const override
+  {
+    assert(current_level_ < test_.num_levels());
+    return Dune::Fem::GridWidth::calcGridWidth(test_.level_grid_part(current_level_));
   }
 
   virtual double compute_on_current_refinement() override

--- a/test/elliptic-swipdg-discretization.hh
+++ b/test/elliptic-swipdg-discretization.hh
@@ -14,11 +14,7 @@
 
 #include <dune/common/timer.hh>
 
-#include <dune/fem/misc/gridwidth.hh>
-
-#include <dune/stuff/common/disable_warnings.hh>
 #include <dune/geometry/quadraturerules.hh>
-#include <dune/stuff/common/reenable_warnings.hh>
 
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
@@ -319,11 +315,31 @@ public:
     return test_.level_grid_view(current_level_).indexSet().size(0);
   }
 
+  //! todo: use grid information from dune-stuff once the diameter calculation is implemented
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
-    return Dune::Fem::GridWidth::calcGridWidth(test_.level_grid_part(current_level_));
+    typedef typename GridViewType::template Codim< 0 >::Iterator EntityIteratorType;
+    const GridViewType grid_view = test_.level_grid_view(current_level_);
+    EntityIteratorType entity_it_end = grid_view.template end< 0 >();
+    double curr_grid_width = 0.0;
+    double norm = 0.0;
+    int corners = 0;
+    for (EntityIteratorType entity_it = grid_view.template begin< 0 >(); entity_it != entity_it_end; ++entity_it) {
+      const auto& entity = *entity_it;
+      corners = entity.geometry().corners();
+      for (int corner1 = 0; corner1 < corners; ++corner1) {
+        for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
+          auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
+          norm = corner_diff.two_norm();
+          if (Dune::FloatCmp::gt(norm, curr_grid_width))
+            curr_grid_width = norm;
+        }
+      }
+    }
+    return curr_grid_width;
   }
+
 
   virtual double compute_on_current_refinement() override
   {

--- a/test/elliptic-swipdg-discretization.hh
+++ b/test/elliptic-swipdg-discretization.hh
@@ -18,6 +18,7 @@
 
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/grid/boundaryinfo.hh>
+#include <dune/stuff/grid/entity.hh>
 #include <dune/stuff/la/container.hh>
 #include <dune/stuff/la/solver.hh>
 #include <dune/stuff/functions/interfaces.hh>
@@ -315,30 +316,16 @@ public:
     return test_.level_grid_view(current_level_).indexSet().size(0);
   }
 
-  //! todo: use grid information from dune-stuff once the diameter calculation is implemented
   virtual double current_grid_width() const override
   {
     assert(current_level_ < test_.num_levels());
     //get grid_view and first entity from grid_view
     const GridViewType grid_view = test_.level_grid_view(current_level_);
-    auto entity_it = grid_view.template begin< 0 >();
-    assert(entity_it != grid_view.template end< 0 >());
-    const auto& entity = *entity_it;
+    assert(grid_view.template begin< 0 >() != grid_view.template end< 0 >());
+    const auto& entity = *(grid_view.template begin< 0 >());
     //calculate longest straight line within the entity (i.e. between two corners).
-    double curr_grid_width = 0.0;
-    double norm = 0.0;
-    const int corners = entity.geometry().corners();
-    for (int corner1 = 0; corner1 < corners; ++corner1) {
-      for (int corner2 = corner1 + 1; corner2 < corners; ++corner2) {
-        auto corner_diff = entity.geometry().corner(corner1) - entity.geometry().corner(corner2);
-        norm = corner_diff.two_norm();
-        if (Dune::FloatCmp::gt(norm, curr_grid_width))
-          curr_grid_width = norm;
-      }
-    }
-    return curr_grid_width;
+    return Dune::Stuff::Grid::entity_diameter(entity);
   } // ... current_grid_width()
-
 
   virtual double compute_on_current_refinement() override
   {

--- a/test/products_boundaryl2.hh
+++ b/test/products_boundaryl2.hh
@@ -6,6 +6,8 @@
 #ifndef DUNE_GDT_TEST_PRODUCTS_BOUNDARYL2_HH
 #define DUNE_GDT_TEST_PRODUCTS_BOUNDARYL2_HH
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <dune/stuff/la/container/common.hh>
 
 #include <dune/gdt/discretefunction/default.hh>
@@ -33,7 +35,7 @@ struct BoundaryL2ProductBase
   typedef Stuff::Functions::Expression< EntityType, DomainFieldType, dimDomain, RangeFieldType, dimRange > FunctionType;
 
   BoundaryL2ProductBase()
-   : grid_(GridProviderType(0.0, 1.0, dsc_grid_elements()).grid_ptr())
+   : grid_(GridProviderType(0.0, 1.0, boost::numeric_cast< unsigned int >(dsc_grid_elements())).grid_ptr())
    , space_(Dune::GDT::SpaceTools::GridPartView< SpaceType >::create_leaf(*grid_))
    , one_("x", "1.0", 0)
   {}

--- a/test/products_elliptic.hh
+++ b/test/products_elliptic.hh
@@ -6,6 +6,8 @@
 #ifndef DUNE_GDT_TEST_PRODUCTS_ELLIPTIC_HH
 #define DUNE_GDT_TEST_PRODUCTS_ELLIPTIC_HH
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <dune/stuff/la/container/common.hh>
 #include <dune/stuff/functions/constant.hh>
 #include <dune/stuff/functions/expression.hh>
@@ -38,7 +40,7 @@ struct EllipticProductBase
       < EntityType, DomainFieldType, dimDomain, RangeFieldType, dimDomain, dimDomain > TensorType;
 
   EllipticProductBase()
-   : grid_(GridProviderType(0.0, 1.0, dsc_grid_elements()).grid_ptr())
+   : grid_(GridProviderType(0.0, 1.0, boost::numeric_cast< unsigned int >(dsc_grid_elements())).grid_ptr())
    , leaf_view_(Dune::GDT::SpaceTools::GridPartView< SpaceType >::create_leaf(*grid_))
    , space_(leaf_view_)
    , one_("x", "1.0", 1, "constant gradient", {{"1.0", "1.0", "1.0"}})

--- a/test/products_weightedl2.hh
+++ b/test/products_weightedl2.hh
@@ -6,6 +6,8 @@
 #ifndef DUNE_GDT_TEST_PRODUCTS_WEIGHTEDL2_HH
 #define DUNE_GDT_TEST_PRODUCTS_WEIGHTEDL2_HH
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <dune/stuff/la/container/common.hh>
 
 #include <dune/gdt/discretefunction/default.hh>
@@ -33,7 +35,7 @@ struct WeightedL2ProductBase
   typedef Stuff::Functions::Expression< EntityType, DomainFieldType, dimDomain, RangeFieldType, dimRange > FunctionType;
 
   WeightedL2ProductBase()
-   : grid_(GridProviderType(0.0, 1.0, dsc_grid_elements()).grid_ptr())
+   : grid_(GridProviderType(0.0, 1.0, boost::numeric_cast< unsigned int >(dsc_grid_elements())).grid_ptr())
    , space_(Dune::GDT::SpaceTools::GridPartView< SpaceType >::create_leaf(*grid_))
    , one_("x", "1.0", 0)
   {}


### PR DESCRIPTION
Just readds the current_grid_width() function that was removed in 583e614250e4d60e097051a4de2d7023134dae6f, because otherwise the compiler complains about pure virtual functions. Don't know if this is the intended fix, so please have a look at it before merging, @renemilk.