### PR TITLE
[discretefunction.local] refactor local DoF vector

### DIFF
--- a/dune/gdt/discretefunction/local.hh
+++ b/dune/gdt/discretefunction/local.hh
@@ -130,15 +130,8 @@ class ConstLocalDiscreteFunction
                                           typename SpaceImp::DomainFieldType, SpaceImp::dimDomain,
                                           typename SpaceImp::RangeFieldType, SpaceImp::dimRange, SpaceImp::dimRangeCols >
 {
-  static_assert(std::is_base_of< SpaceInterface< typename SpaceImp::Traits,
-                                                 SpaceImp::dimDomain,
-                                                 SpaceImp::dimRange,
-                                                 SpaceImp::dimRangeCols >,
-                                 SpaceImp >::value,
-                "SpaceImp has to be derived from SpaceInterface!");
-  static_assert(std::is_base_of
-                < Dune::Stuff::LA::VectorInterface< typename VectorImp::Traits, typename VectorImp::Traits::ScalarType >,
-                  VectorImp >::value,
+  static_assert(is_space< SpaceImp >::value, "SpaceImp has to be derived from SpaceInterface!");
+  static_assert(Stuff::LA::is_vector< VectorImp >::value,
                 "VectorImp has to be derived from Stuff::LA::VectorInterface!");
   static_assert(std::is_same< typename SpaceImp::RangeFieldType, typename VectorImp::ScalarType >::value,
                 "Types do not match!");

--- a/dune/gdt/discretefunction/local.hh
+++ b/dune/gdt/discretefunction/local.hh
@@ -9,6 +9,8 @@
 #include <vector>
 #include <type_traits>
 
+#include <dune/common/deprecated.hh>
+
 #include <dune/stuff/common/memory.hh>
 #include <dune/stuff/functions/interfaces.hh>
 #include <dune/stuff/la/container/interfaces.hh>
@@ -21,7 +23,9 @@ namespace GDT {
 
 
 template< class VectorImp >
-class ConstLocalDoFVector
+class
+  DUNE_DEPRECATED_MSG("Not needed any more (02.02.2015)!")
+      ConstLocalDoFVector
 {
   static_assert(std::is_base_of
                 < Stuff::LA::VectorInterface< typename VectorImp::Traits, typename VectorImp::Traits::ScalarType >,
@@ -82,7 +86,9 @@ std::ostream& operator<<(std::ostream& out, const ConstLocalDoFVector< V >& vect
 
 
 template< class VectorImp >
-class LocalDoFVector
+class
+  DUNE_DEPRECATED_MSG("Not needed any more (02.02.2015)!")
+      LocalDoFVector
   : public ConstLocalDoFVector< VectorImp >
 {
   typedef ConstLocalDoFVector< VectorImp > BaseType;

--- a/dune/gdt/discretefunction/local.hh
+++ b/dune/gdt/discretefunction/local.hh
@@ -145,20 +145,12 @@ public:
   typedef VectorImp                     VectorType;
   typedef typename BaseType::EntityType EntityType;
 
-  typedef typename BaseType::DomainFieldType  DomainFieldType;
-  static const unsigned int                   dimDomain = BaseType::dimDomain;
-  typedef typename BaseType::DomainType       DomainType;
-
-  typedef typename BaseType::RangeFieldType RangeFieldType;
-  static const unsigned int                 dimRangeRows = BaseType::dimRangeCols;
-  static const unsigned int                 dimRangeCols = BaseType::dimRangeCols;
-  typedef typename BaseType::RangeType      RangeType;
-
+  typedef typename BaseType::DomainType        DomainType;
+  typedef typename BaseType::RangeFieldType    RangeFieldType;
+  typedef typename BaseType::RangeType         RangeType;
   typedef typename BaseType::JacobianRangeType JacobianRangeType;
-private:
-  typedef typename SpaceType::BaseFunctionSetType BaseFunctionSetType;
 
-public:
+  typedef typename SpaceType::BaseFunctionSetType BaseFunctionSetType;
 
   ConstLocalDiscreteFunction(const SpaceType& space, const VectorType& global_vector, const EntityType& ent)
     : BaseType(ent)
@@ -250,20 +242,6 @@ public:
   typedef typename BaseType::VectorType VectorType;
   typedef typename BaseType::EntityType EntityType;
 
-  typedef typename BaseType::DomainFieldType  DomainFieldType;
-  static const unsigned int                   dimDomain = BaseType::dimDomain;
-  typedef typename BaseType::DomainType       DomainType;
-
-  typedef typename BaseType::RangeFieldType RangeFieldType;
-  static const unsigned int                 dimRangeRows = BaseType::dimRangeCols;
-  static const unsigned int                 dimRangeCols = BaseType::dimRangeCols;
-  typedef typename BaseType::RangeType      RangeType;
-
-  typedef typename BaseType::JacobianRangeType JacobianRangeType;
-private:
-  typedef typename SpaceType::BaseFunctionSetType BaseFunctionSetType;
-
-public:
   LocalDiscreteFunction(const SpaceType& space, VectorType& global_vector, const EntityType& ent)
     : BaseType(space, global_vector, ent)
     , global_vector_(global_vector)

--- a/dune/gdt/discretefunction/local.hh
+++ b/dune/gdt/discretefunction/local.hh
@@ -248,7 +248,6 @@ public:
     , local_DoF_vector_(const_local_DoF_vector_)
   {}
 
-  //! previous comment questioned validity, defaulting this doesn't touch that question
   LocalDiscreteFunction(ThisType&& source) = default;
 
   LocalDiscreteFunction(const ThisType& other) = delete;

--- a/dune/gdt/operators/oswaldinterpolation.hh
+++ b/dune/gdt/operators/oswaldinterpolation.hh
@@ -487,7 +487,7 @@ private:
           // do the oswald projection
           const size_t num_DoFS_per_vertex = global_vertex_id_to_global_DoF_id_map[global_vertex_id].size();
           // * get the source DoF
-          const FieldType source_DoF_value = local_source_DoF_vector.get(local_DoF_id);
+          const FieldType source_DoF_value = local_source_DoF_vector[local_DoF_id];
           // * and add it to all target DoFs
           for (size_t target_global_DoF_id : global_vertex_id_to_global_DoF_id_map[global_vertex_id])
             range.vector().add_to_entry(target_global_DoF_id, source_DoF_value / num_DoFS_per_vertex);

--- a/dune/gdt/operators/projections.hh
+++ b/dune/gdt/operators/projections.hh
@@ -134,12 +134,12 @@ private:
     assert(lagrange_points.size() == local_range_DoF_vector.size());
     size_t kk = 0;
     for (size_t ii = 0; ii < lagrange_points.size(); ++ii) {
-      if (std::isinf(local_range_DoF_vector.get(kk))) {
+      if (std::isinf(local_range_DoF_vector[kk])) {
         const auto& lagrange_point = lagrange_points[ii];
         // evaluate source function
         const auto source_value = local_source.evaluate(lagrange_point);
         for (size_t jj = 0; jj < dimRange; ++jj, ++kk)
-          local_range_DoF_vector.set(kk, source_value[jj]);
+          local_range_DoF_vector[kk] = source_value[jj];
       }
       else
         kk += dimRange;
@@ -308,7 +308,7 @@ private:
       // set local DoFs
       auto local_range_vector = local_range->vector();
       for (size_t ii = 0; ii < local_range_vector.size(); ++ii)
-        local_range_vector.set(ii, local_DoFs[ii]);
+        local_range_vector[ii] = local_DoFs[ii];
     } // walk the grid
   } // ... apply_local_l2_projection_(...)
 
@@ -565,7 +565,7 @@ public:
         const auto lagrange_points = range_.space().lagrange_points(entity);
         assert(lagrange_points.size() == local_range_DoF_vector.size());
         for (const size_t& local_DoF_id : local_dirichlet_DoFs)
-          local_range_DoF_vector.set(local_DoF_id, local_source->evaluate(lagrange_points[local_DoF_id]));
+          local_range_DoF_vector[local_DoF_id] = local_source->evaluate(lagrange_points[local_DoF_id]);
       }
     }
   } // ... apply_local(...)

--- a/dune/gdt/operators/projections.hh
+++ b/dune/gdt/operators/projections.hh
@@ -306,7 +306,7 @@ private:
       // compute local DoFs
       Stuff::LA::Solver< LocalMatrixType >(local_matrix).apply(local_vector, local_DoFs);
       // set local DoFs
-      auto local_range_vector = local_range->vector();
+      auto& local_range_vector = local_range->vector();
       for (size_t ii = 0; ii < local_range_vector.size(); ++ii)
         local_range_vector[ii] = local_DoFs[ii];
     } // walk the grid

--- a/dune/gdt/operators/prolongations.hh
+++ b/dune/gdt/operators/prolongations.hh
@@ -212,7 +212,7 @@ private:
       auto local_range_vector = local_range->vector();
       assert(local_range_vector.size() == local_DoFs.size());
       for (size_t ii = 0; ii < local_range_vector.size(); ++ii)
-        local_range_vector.set(ii, local_DoFs.get_entry(ii));
+        local_range_vector[ii] = local_DoFs.get_entry(ii);
     } // walk the grid
   } // ... prolong_onto_dg_fem_localfunctions_wrapper(...)
 
@@ -343,7 +343,7 @@ private:
     size_t kk = 0;
     assert(source_entity_ptr_unique_ptrs.size() >= lagrange_points.size());
     for (size_t ii = 0; ii < lagrange_points.size(); ++ii) {
-      if (std::isinf(range_DoF_vector.get(kk))) {
+      if (std::isinf(range_DoF_vector[kk])) {
         const auto& global_point = lagrange_points[ii];
         // evaluate source function
         const auto& source_entity_ptr_unique_ptr = source_entity_ptr_unique_ptrs[ii];
@@ -354,10 +354,10 @@ private:
           const auto local_source = source.local_function(source_entity);
           const auto source_value = local_source->evaluate(local_source_point);
           for (size_t jj = 0; jj < dimRange; ++jj, ++kk)
-            range_DoF_vector.set(kk, source_value[jj]);
+            range_DoF_vector[kk] = source_value[jj];
         } else
           for (size_t jj = 0; jj < dimRange; ++jj, ++kk)
-            range_DoF_vector.set(kk, 0.0);
+            range_DoF_vector[kk] = 0.0;
       }
       else
         kk += dimRange;

--- a/dune/gdt/operators/prolongations.hh
+++ b/dune/gdt/operators/prolongations.hh
@@ -209,7 +209,7 @@ private:
                    << "This was the original error: " << ee.what());
       }
       // set local DoFs
-      auto local_range_vector = local_range->vector();
+      auto& local_range_vector = local_range->vector();
       assert(local_range_vector.size() == local_DoFs.size());
       for (size_t ii = 0; ii < local_range_vector.size(); ++ii)
         local_range_vector[ii] = local_DoFs.get_entry(ii);
@@ -327,7 +327,7 @@ private:
       assert(source_entity_ptrs.size() == lagrange_points.size());
       // get range
       auto local_range = range.local_discrete_function(entity);
-      auto local_range_DoF_vector = local_range->vector();
+      auto& local_range_DoF_vector = local_range->vector();
       // do the actual work (see below)
       apply_local(source, lagrange_points, source_entity_ptrs, local_range_DoF_vector);
     } // walk the grid

--- a/test/operators_oswaldinterpolation.hh
+++ b/test/operators_oswaldinterpolation.hh
@@ -52,7 +52,7 @@ struct Oswald_Interpolation_Operator
       if (center[0] > 0.5)
         value = 1.0;
       auto local_source = source.local_discrete_function(entity);
-      auto local_source_DoF_vector = local_source->vector();
+      auto& local_source_DoF_vector = local_source->vector();
       for (size_t local_DoF = 0; local_DoF < local_source_DoF_vector.size(); ++local_DoF)
         local_source_DoF_vector[local_DoF] = value;
     }

--- a/test/operators_oswaldinterpolation.hh
+++ b/test/operators_oswaldinterpolation.hh
@@ -54,7 +54,7 @@ struct Oswald_Interpolation_Operator
       auto local_source = source.local_discrete_function(entity);
       auto local_source_DoF_vector = local_source->vector();
       for (size_t local_DoF = 0; local_DoF < local_source_DoF_vector.size(); ++local_DoF)
-        local_source_DoF_vector.set(local_DoF, value);
+        local_source_DoF_vector[local_DoF] = value;
     }
     // apply operator
     VectorType range_vector(space.mapper().size());


### PR DESCRIPTION
This pr adds a complete rewrite of the way local DoF vectors are handled. It may have some severe consequences (see the commit message of 51ebd777ffda72f003bf1020215c4bfeaffa2bc4).

* We want to make sure we understand the implications.
* We need to test if this breaks parallel code (we = @renemilk). I would hope not, but it might as well be. Compared to the situation before there might be a value mismatch as long as local discrete functions exist, while before it was only while the internal data race on accessing the global vector held. This might even be a good thing, but I can not say for sure.

So please test this and think about this thoroughly and do not merge this pr directly. This is of course related to #5.