### PR TITLE
Two small fixes

### DIFF
--- a/dune/gdt/spaces/continuouslagrange/base.hh
+++ b/dune/gdt/spaces/continuouslagrange/base.hh
@@ -177,7 +177,7 @@ public:
   template< class S, size_t d, size_t r, size_t rC >
   void local_constraints(const SpaceInterface< S, d, r, rC >& other,
                          const EntityType& entity,
-                         Constraints::Dirichlet< IntersectionType, RangeFieldType >& ret) const
+                         DirichletConstraints< IntersectionType >& ret) const
   {
     // check
     static_assert(polOrder == 1, "Not tested for higher polynomial orders!");

--- a/dune/gdt/tests/linearelliptic/eocexpectations.hh
+++ b/dune/gdt/tests/linearelliptic/eocexpectations.hh
@@ -6,6 +6,7 @@
 #ifndef DUNE_GDT_TESTS_LINEARELLIPTIC_EOCEXPECTATIONS_HH
 #define DUNE_GDT_TESTS_LINEARELLIPTIC_EOCEXPECTATIONS_HH
 
+#include <dune/stuff/common/type_utils.hh>
 #include <dune/stuff/test/gtest/gtest.h>
 
 #include "discretizers/base.hh"


### PR DESCRIPTION
Fixes for compilation errors I found when compiling headercheck and all tests to test the changed Functions::Expression implementation.